### PR TITLE
Use the `Error` interface from the CDK DA repo

### DIFF
--- a/interop/executor.go
+++ b/interop/executor.go
@@ -10,8 +10,8 @@ import (
 	"github.com/0xPolygon/beethoven/tx"
 	"github.com/0xPolygon/beethoven/types"
 
+	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/client"
-	rpctypes "github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
 	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -168,11 +168,11 @@ func (e *Executor) Settle(ctx context.Context, signedTx tx.SignedTx, dbTx pgx.Tx
 	return signedTx.Tx.Hash(), nil
 }
 
-func (e *Executor) GetTxStatus(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (result string, err rpctypes.Error) {
+func (e *Executor) GetTxStatus(ctx context.Context, hash common.Hash, dbTx pgx.Tx) (result string, err jRPC.Error) {
 	res, innerErr := e.ethTxMan.Result(ctx, ethTxManOwner, hash.Hex(), dbTx)
 	if innerErr != nil {
 		result = "0x0"
-		err = rpctypes.NewRPCError(rpctypes.DefaultErrorCode, fmt.Sprintf("failed to get tx, error: %s", innerErr))
+		err = jRPC.NewRPCError(jRPC.DefaultErrorCode, fmt.Sprintf("failed to get tx, error: %s", innerErr))
 
 		return
 	}

--- a/interop/executor_test.go
+++ b/interop/executor_test.go
@@ -6,10 +6,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/0xPolygon/beethoven/config"
-	"github.com/0xPolygon/beethoven/mocks"
-	"github.com/0xPolygon/beethoven/tx"
-
+	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	rpctypes "github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
 	"github.com/0xPolygonHermez/zkevm-node/log"
@@ -18,6 +15,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/0xPolygon/beethoven/config"
+	"github.com/0xPolygon/beethoven/mocks"
+	"github.com/0xPolygon/beethoven/tx"
 )
 
 func TestNewExecutor(t *testing.T) {
@@ -269,7 +270,7 @@ func TestExecutor_GetTxStatus(t *testing.T) {
 
 	hash := common.HexToHash("0x1234567890abcdef")
 	expectedResult := "0x1"
-	expectedError := rpctypes.NewRPCError(rpctypes.DefaultErrorCode, "failed to get tx, error: sampleError")
+	expectedError := jRPC.NewRPCError(rpctypes.DefaultErrorCode, "failed to get tx, error: sampleError")
 
 	ethTxManager.On("Result", mock.Anything, ethTxManOwner, hash.Hex(), dbTx).
 		Return(ethtxmanager.MonitoredTxResult{


### PR DESCRIPTION
This PR aligns function signature for interop functions so that it conforms to the expected signature, where second return value must be of type `rpc.Error` from the cdk-data-availability repo (https://github.com/0xPolygon/cdk-data-availability/blob/10cc1631e5a67761e655d9cbd3a9e3016fb3f757/rpc/error.go#L33-L37), instead the one used from the zk-evm-node repo (https://github.com/0xPolygonHermez/zkevm-node/blob/76e3118a9bc70b261b3c67d01fa9fcf7be3712de/jsonrpc/types/errors.go#L31-L35).

The panic was caused by this check, which was failing https://github.com/0xPolygon/cdk-data-availability/blob/10cc1631e5a67761e655d9cbd3a9e3016fb3f757/rpc/handler.go#L256-L259.