### PR TITLE
Remove zk-evm/log dependancy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,7 +13,6 @@ import (
 	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
 	dbConf "github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -27,6 +26,7 @@ import (
 	"github.com/0xPolygon/agglayer/db"
 	"github.com/0xPolygon/agglayer/etherman"
 	"github.com/0xPolygon/agglayer/interop"
+	"github.com/0xPolygon/agglayer/log"
 	"github.com/0xPolygon/agglayer/network"
 	"github.com/0xPolygon/agglayer/rpc"
 )
@@ -181,7 +181,9 @@ func start(cliCtx *cli.Context) error {
 }
 
 func setupLog(c log.Config) {
-	log.Init(c)
+	if err := log.InitLogger(c); err != nil {
+		panic(fmt.Errorf("could not setup logger. Err: %w", err))
+	}
 }
 
 func createMetricProvider() (*metric.MeterProvider, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -6,11 +6,11 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/0xPolygon/agglayer/log"
 	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
 	"github.com/0xPolygonHermez/zkevm-node/config/types"
 	"github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/mitchellh/mapstructure"

--- a/db/migrations.go
+++ b/db/migrations.go
@@ -3,10 +3,11 @@ package db
 import (
 	"embed"
 
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/jackc/pgx/v4/stdlib"
 	migrate "github.com/rubenv/sql-migrate"
+
+	"github.com/0xPolygon/agglayer/log"
 )
 
 //go:embed migrations

--- a/etherman/etherman.go
+++ b/etherman/etherman.go
@@ -10,9 +10,9 @@ import (
 	"github.com/0xPolygon/agglayer/config"
 	"github.com/0xPolygon/agglayer/tx"
 
+	"github.com/0xPolygon/agglayer/log"
 	"github.com/0xPolygonHermez/zkevm-node/etherman/smartcontracts/polygonrollupmanager"
 	"github.com/0xPolygonHermez/zkevm-node/etherman/smartcontracts/polygonzkevm"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/0xPolygonHermez/zkevm-node/state"
 	"github.com/0xPolygonHermez/zkevm-node/test/operations"
 	"github.com/ethereum/go-ethereum"

--- a/interop/executor.go
+++ b/interop/executor.go
@@ -9,10 +9,11 @@ import (
 	"github.com/0xPolygon/agglayer/config"
 	"github.com/0xPolygon/agglayer/tx"
 	"github.com/0xPolygon/agglayer/types"
+	"go.uber.org/zap"
 
+	"github.com/0xPolygon/agglayer/log"
 	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
 	"github.com/0xPolygonHermez/zkevm-node/jsonrpc/client"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jackc/pgx/v4"
@@ -27,7 +28,7 @@ func (zc *zkEVMClientCreator) NewClient(rpc string) types.IZkEVMClient {
 }
 
 type Executor struct {
-	logger             *log.Logger
+	logger             *zap.SugaredLogger
 	interopAdminAddr   common.Address
 	config             *config.Config
 	ethTxMan           types.IEthTxManager
@@ -35,7 +36,7 @@ type Executor struct {
 	ZkEVMClientCreator types.IZkEVMClientClientCreator
 }
 
-func New(logger *log.Logger, cfg *config.Config,
+func New(logger *zap.SugaredLogger, cfg *config.Config,
 	interopAdminAddr common.Address,
 	etherman types.IEtherman,
 	ethTxManager types.IEthTxManager,

--- a/interop/executor_test.go
+++ b/interop/executor_test.go
@@ -6,10 +6,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/0xPolygon/agglayer/log"
 	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	rpctypes "github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,215 @@
+package log
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
+
+	"github.com/hermeznetwork/tracerr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LogEnvironment represents the possible log environments.
+type LogEnvironment string
+
+const (
+	// EnvironmentProduction production log environment.
+	EnvironmentProduction = LogEnvironment("production")
+	// EnvironmentDevelopment development log environment.
+	EnvironmentDevelopment = LogEnvironment("development")
+)
+
+// Config for log
+type Config struct {
+	// Environment defining the log format ("production" or "development").
+	Environment LogEnvironment `mapstructure:"Environment" jsonschema:"enum=production,enum=development"`
+	// Level of log. As lower value more logs are going to be generated
+	Level string `mapstructure:"Level" jsonschema:"enum=debug,enum=info,enum=warn,enum=error,enum=dpanic,enum=panic,enum=fatal"`
+	// Outputs
+	Outputs []string `mapstructure:"Outputs"`
+}
+
+// root logger
+var log atomic.Pointer[zap.SugaredLogger]
+
+// InitLogger creates the logger with defined level.
+// Outputs parameter defines the outputs where the logs will be sent.
+// By default, outputs contains "stdout", which prints the
+// logs at the output of the process. To add a log file as output, the path
+// should be added at the outputs array. To avoid printing the logs but storing
+// them on a file, can use []string{"pathtofile.log"}
+func InitLogger(cfg Config) error {
+	logger, err := newLogger(cfg)
+	if err != nil {
+		return err
+	}
+
+	log.Store(logger)
+
+	return nil
+}
+
+// newLogger creates a new logger based on the provided configuration.
+// It initializes the log level, output paths, and additional fields.
+// The logger is built using the zap library and returns a pointer to the Logger struct.
+// If an error occurs during the initialization or building of the logger, an error is returned.
+func newLogger(cfg Config) (*zap.SugaredLogger, error) {
+	var level zap.AtomicLevel
+	err := level.UnmarshalText([]byte(cfg.Level))
+	if err != nil {
+		return nil, fmt.Errorf("error on setting log level: %s", err)
+	}
+
+	var zapCfg zap.Config
+
+	switch cfg.Environment {
+	case EnvironmentProduction:
+		zapCfg = zap.NewProductionConfig()
+	default:
+		zapCfg = zap.NewDevelopmentConfig()
+		zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	}
+	zapCfg.Level = level
+	zapCfg.OutputPaths = cfg.Outputs
+	zapCfg.InitialFields = map[string]interface{}{
+		"pid": os.Getpid(),
+	}
+
+	logger, err := zapCfg.Build()
+	if err != nil {
+		return nil, err
+	}
+
+	defer logger.Sync() //nolint:gosec,errcheck
+
+	// skip 2 callers: one for our wrapper methods and one for the package functions
+	withOptions := logger.WithOptions(zap.AddCallerSkip(2)) //nolint:gomnd
+
+	return withOptions.Sugar(), nil
+}
+
+// getLogger returns the logger instance.
+// If a logger instance is already loaded, it returns that instance.
+// Otherwise, it creates a new logger with default settings and stores it for future use.
+// The default logger level is set to "debug" and the output is directed to stderr.
+// The logger is intended for use in a development environment.
+func getLogger() *zap.SugaredLogger {
+	l := log.Load()
+	if l != nil {
+		return l
+	}
+
+	// default level: debug
+	zapLogger, err := newLogger(Config{
+		Environment: EnvironmentDevelopment,
+		Level:       "debug",
+		Outputs:     []string{"stderr"},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	log.Store(zapLogger)
+
+	return log.Load()
+}
+
+// Info calls log.Info on the root Logger.
+func Info(args ...interface{}) {
+	getLogger().Info(args...)
+}
+
+// Warn calls log.Warn on the root Logger.
+func Warn(args ...interface{}) {
+	getLogger().Warn(args...)
+}
+
+// Error calls log.Error on the root Logger.
+func Error(args ...interface{}) {
+	args = appendStackTraceMaybeArgs(args)
+	getLogger().Error(args...)
+}
+
+// Fatal calls log.Fatal on the root Logger.
+func Fatal(args ...interface{}) {
+	args = appendStackTraceMaybeArgs(args)
+	getLogger().Fatal(args...)
+}
+
+// Debugf calls log.Debugf on the root Logger.
+func Debugf(template string, args ...interface{}) {
+	getLogger().Debugf(template, args...)
+}
+
+// Infof calls log.Infof on the root Logger.
+func Infof(template string, args ...interface{}) {
+	getLogger().Infof(template, args...)
+}
+
+// Warnf calls log.Warnf on the root Logger.
+func Warnf(template string, args ...interface{}) {
+	getLogger().Warnf(template, args...)
+}
+
+// Fatalf calls log.Fatalf on the root Logger.
+func Fatalf(template string, args ...interface{}) {
+	args = appendStackTraceMaybeArgs(args)
+	getLogger().Fatalf(template, args...)
+}
+
+// Errorf calls log.Errorf on the root logger and stores the error message into
+// the ErrorFile.
+func Errorf(template string, args ...interface{}) {
+	args = appendStackTraceMaybeArgs(args)
+	getLogger().Errorf(template, args...)
+}
+
+// WithFields returns a new Logger (derived from the root one) with additional
+// fields as per keyValuePairs.  The root Logger instance is not affected.
+func WithFields(keyValuePairs ...interface{}) *zap.SugaredLogger {
+	l := getLogger().With(keyValuePairs...)
+
+	// since we are returning a new instance, remove one caller from the
+	// stack, because we'll be calling the retruned Logger methods
+	// directly, not the package functions.
+	x := l.WithOptions(zap.AddCallerSkip(-1))
+	l = x
+
+	return l
+}
+
+// sprintStackTrace formats the given stack trace into a string.
+// It skips the deepest frame because it belongs to the go runtime and is not relevant.
+// The formatted string includes the file path, line number, and function name for each frame.
+func sprintStackTrace(st []tracerr.Frame) string {
+	builder := strings.Builder{}
+	// Skip deepest frame because it belongs to the go runtime and we don't
+	// care about it.
+	if len(st) > 0 {
+		st = st[:len(st)-1]
+	}
+
+	for _, f := range st {
+		builder.WriteString(fmt.Sprintf("\n%s:%d %s()", f.Path, f.Line, f.Func))
+	}
+
+	builder.WriteString("\n")
+
+	return builder.String()
+}
+
+// appendStackTraceMaybeArgs will append the stacktrace to the args
+func appendStackTraceMaybeArgs(args []interface{}) []interface{} {
+	for i := range args {
+		if err, ok := args[i].(error); ok {
+			err = tracerr.Wrap(err)
+			st := tracerr.StackTrace(err)
+
+			return append(args, sprintStackTrace(st))
+		}
+	}
+
+	return args
+}

--- a/rpc/rpc.go
+++ b/rpc/rpc.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/0xPolygon/agglayer/log"
 	jRPC "github.com/0xPolygon/cdk-data-availability/rpc"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/0xPolygon/agglayer/config"

--- a/rpc/rpc_test.go
+++ b/rpc/rpc_test.go
@@ -9,10 +9,10 @@ import (
 	"github.com/0xPolygon/agglayer/interop"
 	"github.com/0xPolygon/agglayer/mocks"
 
+	"github.com/0xPolygon/agglayer/log"
 	agglayerTypes "github.com/0xPolygon/agglayer/rpc/types"
 	"github.com/0xPolygonHermez/zkevm-node/ethtxmanager"
 	validiumTypes "github.com/0xPolygonHermez/zkevm-node/jsonrpc/types"
-	"github.com/0xPolygonHermez/zkevm-node/log"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,11 +7,11 @@ sonar.projectName=agglayer
 sonar.organization=0xpolygon
 
 sonar.sources=.
-sonar.exclusions=**/*_test.go,**/vendor/**,mocks/**,cmd/main.go
-
+sonar.exclusions=**/*_test.go,**/vendor/**,mocks/**,cmd/main.go,log/**
+ 
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
-sonar.test.exclusions=**/vendor/**,mocks/**
+sonar.test.exclusions=**/vendor/**,mocks/**,log/**
 sonar.issue.enforceSemantic=true
 
 # =====================================================

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/0xPolygonHermez/zkevm-node/log"
+	"github.com/0xPolygon/agglayer/log"
 	"github.com/0xPolygonHermez/zkevm-node/test/operations"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"


### PR DESCRIPTION
This PR removes the `zk-evm/log` dependency by implementing its logger (with a minimum set of functions) using the `go.uber` library.