### PR TITLE
Expose configurable GasOffset in the `agglayer`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 docker/data
 .idea
 coverage.out
+.vscode/launch.json

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -72,6 +72,7 @@ func start(cliCtx *cli.Context) error {
 
 	setupLog(c.Log)
 
+	log.Errorf("EthTxManager config%+v", c.EthTxManager)
 	// Load private key
 	pk, err := config.NewKeyFromKeystore(c.EthTxManager.PrivateKeys[0])
 	if err != nil {
@@ -116,7 +117,7 @@ func start(cliCtx *cli.Context) error {
 	if err != nil {
 		log.Fatal(err)
 	}
-	etm := ethtxmanager.New(c.EthTxManager, &ethMan, ethTxManagerStorage, &ethMan)
+	etm := ethtxmanager.New(c.EthTxManager.Config, &ethMan, ethTxManagerStorage, &ethMan)
 
 	// Create opentelemetry metric provider
 	metricProvider, err := createMetricProvider()

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ type Telemetry struct {
 }
 
 type EthTxManagerConfig struct {
-	ethtxmanager.Config `mapstructure:"Base"`
+	ethtxmanager.Config `mapstructure:",squash"`
 	GasOffset           uint64 `mapstructure:"GasOffset"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,13 +27,13 @@ type FullNodeRPCs map[uint32]string
 
 // Config represents the full configuration of the data node
 type Config struct {
-	FullNodeRPCs FullNodeRPCs        `mapstructure:"FullNodeRPCs"`
-	RPC          jRPC.Config         `mapstructure:"RPC"`
-	Log          log.Config          `mapstructure:"Log"`
-	DB           db.Config           `mapstructure:"DB"`
-	EthTxManager ethtxmanager.Config `mapstructure:"EthTxManager"`
-	L1           L1Config            `mapstructure:"L1"`
-	Telemetry    Telemetry           `mapstructure:"Telemetry"`
+	FullNodeRPCs FullNodeRPCs       `mapstructure:"FullNodeRPCs"`
+	RPC          jRPC.Config        `mapstructure:"RPC"`
+	Log          log.Config         `mapstructure:"Log"`
+	DB           db.Config          `mapstructure:"DB"`
+	EthTxManager EthTxManagerConfig `mapstructure:"EthTxManager"`
+	L1           L1Config           `mapstructure:"L1"`
+	Telemetry    Telemetry          `mapstructure:"Telemetry"`
 }
 
 type L1Config struct {
@@ -44,6 +44,11 @@ type L1Config struct {
 
 type Telemetry struct {
 	PrometheusAddr string
+}
+
+type EthTxManagerConfig struct {
+	ethtxmanager.Config `mapstructure:"Base"`
+	GasOffset           uint64 `mapstructure:"GasOffset"`
 }
 
 // Load loads the configuration baseed on the cli context

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"flag"
 	"testing"
 
+	"github.com/mitchellh/mapstructure"
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
@@ -22,18 +24,36 @@ func TestLoad(t *testing.T) {
 	})
 
 	t.Run("the agglayer.toml file config", func(t *testing.T) {
-		const configFile = "../docker/data/agglayer/agglayer.toml"
+		const (
+			cfgFile            = "../docker/data/agglayer/agglayer.toml"
+			ethTxManagerCfgKey = "EthTxManager"
+		)
 
+		// simulate command with the cfg flag
 		flags := new(flag.FlagSet)
 		cfgPath := ""
 		flags.StringVar(&cfgPath,
 			FlagCfg,
-			configFile,
+			cfgFile,
 			"config file for the agglayer")
 		ctx := cli.NewContext(nil, flags, nil)
+
+		// read the config independently from the Load function
+		viper.SetConfigFile(cfgFile)
+		err := viper.ReadInConfig()
+		require.NoError(t, err)
+
+		decodeOpts := []viper.DecoderConfigOption{
+			viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(mapstructure.TextUnmarshallerHookFunc())),
+		}
+
+		var ethTxManagerCfg EthTxManagerConfig
+		err = viper.UnmarshalKey(ethTxManagerCfgKey, &ethTxManagerCfg, decodeOpts...)
+		require.NoError(t, err)
 
 		cfg, err := Load(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, cfg)
+		require.Equal(t, ethTxManagerCfg, cfg.EthTxManager)
 	})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,16 +1,39 @@
 package config
 
 import (
+	"flag"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v2"
 )
 
 func TestLoad(t *testing.T) {
-	ctx := cli.NewContext(nil, nil, nil)
-	_ = ctx.Set(FlagCfg, "/path/to/config.yaml")
+	t.Run("default config", func(t *testing.T) {
+		ctx := cli.NewContext(nil, nil, nil)
+		_ = ctx.Set(FlagCfg, "/path/to/config.yaml")
 
-	_, err := Load(ctx)
-	assert.NoError(t, err)
+		cfg, err := Load(ctx)
+		require.NoError(t, err)
+
+		defaultCfg, err := Default()
+		require.NoError(t, err)
+		require.Equal(t, defaultCfg, cfg)
+	})
+
+	t.Run("the agglayer.toml file config", func(t *testing.T) {
+		const configFile = "../docker/data/agglayer/agglayer.toml"
+
+		flags := new(flag.FlagSet)
+		cfgPath := ""
+		flags.StringVar(&cfgPath,
+			FlagCfg,
+			configFile,
+			"config file for the agglayer")
+		ctx := cli.NewContext(nil, flags, nil)
+
+		cfg, err := Load(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, cfg)
+	})
 }

--- a/config/default.go
+++ b/config/default.go
@@ -34,15 +34,14 @@ const DefaultValues = `
 	MaxConns = 200
 
 [EthTxManager]
-	[EthTxManager.Base]
-		FrequencyToMonitorTxs = "1s"
-		WaitTxToBeMined = "2m"
-		ForcedGas = 0
-		GasPriceMarginFactor = 1
-		MaxGasPriceLimit = 0
-		PrivateKeys = [
-			{Path = "/pk/agglayer.keystore", Password = "testonly"},
-		]
+	FrequencyToMonitorTxs = "1s"
+	WaitTxToBeMined = "2m"
+	ForcedGas = 0
+	GasPriceMarginFactor = 1
+	MaxGasPriceLimit = 0
+	PrivateKeys = [
+		{Path = "/pk/agglayer.keystore", Password = "testonly"},
+	]
 	GasOffset = 100000
 
 [L1]

--- a/config/default.go
+++ b/config/default.go
@@ -34,14 +34,16 @@ const DefaultValues = `
 	MaxConns = 200
 
 [EthTxManager]
-	FrequencyToMonitorTxs = "1s"
-	WaitTxToBeMined = "2m"
-	ForcedGas = 0
-	GasPriceMarginFactor = 1
-	MaxGasPriceLimit = 0
-	PrivateKeys = [
-		{Path = "/pk/agglayer.keystore", Password = "testonly"},
-	]
+	[EthTxManager.Base]
+		FrequencyToMonitorTxs = "1s"
+		WaitTxToBeMined = "2m"
+		ForcedGas = 0
+		GasPriceMarginFactor = 1
+		MaxGasPriceLimit = 0
+		PrivateKeys = [
+			{Path = "/pk/agglayer.keystore", Password = "testonly"},
+		]
+	GasOffset = 100000
 
 [L1]
 	ChainID = 1337

--- a/docker/data/agglayer/agglayer.toml
+++ b/docker/data/agglayer/agglayer.toml
@@ -23,15 +23,14 @@
 	MaxConns = 200
 
 [EthTxManager]
-	[EthTxManager.Base]
-		FrequencyToMonitorTxs = "1s"
-		WaitTxToBeMined = "2m"
-		ForcedGas = 0
-		GasPriceMarginFactor = 1
-		MaxGasPriceLimit = 0
-		PrivateKeys = [
-			{Path = "/pk/agglayer.keystore", Password = "testonly"},
-		]
+	FrequencyToMonitorTxs = "1s"
+	WaitTxToBeMined = "2m"
+	ForcedGas = 0
+	GasPriceMarginFactor = 1
+	MaxGasPriceLimit = 0
+	PrivateKeys = [
+		{Path = "/pk/agglayer.keystore", Password = "testonly"},
+	]
 	GasOffset = 100000
 
 [L1]

--- a/docker/data/agglayer/agglayer.toml
+++ b/docker/data/agglayer/agglayer.toml
@@ -23,14 +23,16 @@
 	MaxConns = 200
 
 [EthTxManager]
-	FrequencyToMonitorTxs = "1s"
-	WaitTxToBeMined = "2m"
-	ForcedGas = 0
-	GasPriceMarginFactor = 1
-	MaxGasPriceLimit = 0
-	PrivateKeys = [
-		{Path = "/pk/agglayer.keystore", Password = "testonly"},
-	]
+	[EthTxManager.Base]
+		FrequencyToMonitorTxs = "1s"
+		WaitTxToBeMined = "2m"
+		ForcedGas = 0
+		GasPriceMarginFactor = 1
+		MaxGasPriceLimit = 0
+		PrivateKeys = [
+			{Path = "/pk/agglayer.keystore", Password = "testonly"},
+		]
+	GasOffset = 100000
 
 [L1]
 	ChainID = 1337

--- a/interop/executor.go
+++ b/interop/executor.go
@@ -164,7 +164,7 @@ func (e *Executor) Settle(ctx context.Context, signedTx tx.SignedTx, dbTx pgx.Tx
 		&e.config.L1.RollupManagerContract,
 		big.NewInt(0),
 		l1TxData,
-		0,
+		e.config.EthTxManager.GasOffset,
 		dbTx,
 	); err != nil {
 		return common.Hash{}, fmt.Errorf("failed to add tx to ethTxMan, error: %s", err)


### PR DESCRIPTION
This PR introduces an additional configuration parameter called `GasOffset`. It is introduced to compensate the transactions' gas usage if the estimated gas is near compared to the actual gas needed for the transaction to be executed successfully.
It should mitigate the issue gas limit being too low when a transaction is being sent to an L1.