### PR TITLE
Adding authorized proof signers mapping

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,10 +25,14 @@ const (
 
 type FullNodeRPCs map[uint32]string
 
+// ProofSigners holds the address for authorized signers of proofs for a given rollup ip
+type ProofSigners map[uint32]common.Address
+
 // Config represents the full configuration of the data node
 type Config struct {
 	FullNodeRPCs FullNodeRPCs       `mapstructure:"FullNodeRPCs"`
 	RPC          jRPC.Config        `mapstructure:"RPC"`
+	ProofSigners ProofSigners       `mapstructure:"ProofSigners"`
 	Log          log.Config         `mapstructure:"Log"`
 	DB           db.Config          `mapstructure:"DB"`
 	EthTxManager EthTxManagerConfig `mapstructure:"EthTxManager"`

--- a/config/default.go
+++ b/config/default.go
@@ -19,6 +19,10 @@ const DefaultValues = `
 	WriteTimeout = "60s"
 	MaxRequestsPerIPAndSecond = 5000
 
+# Address should be adjusted
+[ProofSigners]
+#	1 = "0x0000000000000000000000000000000000000000"
+
 [Log]
 	Environment = "development" # "production" or "development"
 	Level = "debug"

--- a/docker/data/agglayer/agglayer.toml
+++ b/docker/data/agglayer/agglayer.toml
@@ -8,6 +8,10 @@
 	WriteTimeout = "60s"
 	MaxRequestsPerIPAndSecond = 5000
 
+# Address should be adjusted
+[ProofSigners]
+# 1 = "0x0000000000000000000000000000000000000000"
+
 [Log]
 	Environment = "development" # "production" or "development"
 	Level = "debug"


### PR DESCRIPTION
The current implementation of the AggLayer service requires that the party submitting the proof sign the request with the trusted sequencer's key. This makes sense given that we can easily verify the trusted sequencer from the rollup contract.

This PR adds an alternative configuration which would allow for a proof to be submitted using a configurable key rather than the sequencer key. This should allow for better isolation of key material because the sequencer key will not need to be used by multiple roles.

Part of the aim here is to be minimally invasive in this changeset. We're not changing the beneficiary logic at all and specifically allowing for an alternative signer.

Most of the testing for this takes place in https://github.com/0xPolygon/kurtosis-cdk/pull/38 allowed me to try a few cases:

- [X] Aggregator using the sequencer key to sign
- [X] Aggregator using a proof signer to sign
- [X] Aggregator sequencer to sign but the full `[ProofSigners]` section is missing
- [X] Test and Verification on Cardona

As an example this is what the config would look like:
```toml
[FullNodeRPCs]
1 = "http://zkevm-node-rpc-001:8123"

[ProofSigners]
1 = "0x7569cc70950726784c8D3bB256F48e43259Cb445"
```
