### PR TITLE
`PostgressDB` created twice

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -131,10 +131,7 @@ func start(cliCtx *cli.Context) error {
 	}
 
 	// Prepare EthTxMan client
-	ethTxManagerStorage, err := txmanager.NewPostgresStorage(c.DB)
-	if err != nil {
-		return err
-	}
+	ethTxManagerStorage := txmanager.NewPostgresStorage(pg)
 	etm := txmanager.New(c.EthTxManager, &ethMan, ethTxManagerStorage, &ethMan)
 
 	// Create opentelemetry metric provider

--- a/txmanager/pgstorage.go
+++ b/txmanager/pgstorage.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	txmTypes "github.com/0xPolygon/agglayer/txmanager/types"
-	"github.com/0xPolygonHermez/zkevm-node/db"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v4"
@@ -22,15 +21,8 @@ type PostgresStorage struct {
 
 // NewPostgresStorage creates a new instance of storage that use
 // postgres to store data
-func NewPostgresStorage(dbCfg db.Config) (*PostgresStorage, error) {
-	db, err := db.NewSQLDB(dbCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &PostgresStorage{
-		db,
-	}, nil
+func NewPostgresStorage(db *pgxpool.Pool) *PostgresStorage {
+	return &PostgresStorage{db}
 }
 
 // Add persist a monitored tx


### PR DESCRIPTION
`PostgressDB` was connected to twice.

This PR just reuses the already setup connection to `db` in the `ethTxManager`. 