### PR TITLE
Include version info in the logs

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,6 +78,9 @@ func start(cliCtx *cli.Context) error {
 
 	setupLog(c.Log)
 
+	agglayer.PrintVersion(os.Stdout)
+	log.Info("Starting application...")
+
 	// Prepare DB
 	pg, err := dbConf.NewSQLDB(c.DB)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -78,8 +78,7 @@ func start(cliCtx *cli.Context) error {
 
 	setupLog(c.Log)
 
-	agglayer.PrintVersion(os.Stdout)
-	log.Info("Starting application...")
+	log.Infof("Starting application...\n%s", agglayer.GetVersionInfo())
 
 	// Prepare DB
 	pg, err := dbConf.NewSQLDB(c.DB)

--- a/log/log.go
+++ b/log/log.go
@@ -9,6 +9,8 @@ import (
 	"github.com/hermeznetwork/tracerr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/0xPolygon/agglayer"
 )
 
 // LogEnvironment represents the possible log environments.
@@ -74,7 +76,8 @@ func newLogger(cfg Config) (*zap.SugaredLogger, error) {
 	zapCfg.Level = level
 	zapCfg.OutputPaths = cfg.Outputs
 	zapCfg.InitialFields = map[string]interface{}{
-		"pid": os.Getpid(),
+		"version": agglayer.Version,
+		"pid":     os.Getpid(),
 	}
 
 	logger, err := zapCfg.Build()

--- a/version.go
+++ b/version.go
@@ -16,10 +16,16 @@ var (
 
 // PrintVersion prints version info into the provided io.Writer.
 func PrintVersion(w io.Writer) {
-	fmt.Fprintf(w, "Version:      %s\n", Version)
-	fmt.Fprintf(w, "Git revision: %s\n", GitRev)
-	fmt.Fprintf(w, "Git branch:   %s\n", GitBranch)
-	fmt.Fprintf(w, "Go version:   %s\n", runtime.Version())
-	fmt.Fprintf(w, "Built:        %s\n", BuildDate)
-	fmt.Fprintf(w, "OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprint(w, GetVersionInfo())
+}
+
+// GetVersionInfo returns version information as a formatted string.
+func GetVersionInfo() string {
+	versionInfo := fmt.Sprintf("Version:      %s\n", Version)
+	versionInfo += fmt.Sprintf("Git revision: %s\n", GitRev)
+	versionInfo += fmt.Sprintf("Git branch:   %s\n", GitBranch)
+	versionInfo += fmt.Sprintf("Go version:   %s\n", runtime.Version())
+	versionInfo += fmt.Sprintf("Built:        %s\n", BuildDate)
+	versionInfo += fmt.Sprintf("OS/Arch:      %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	return versionInfo
 }


### PR DESCRIPTION
The PR introduces version metadata info printed out on the application startup

For example:
```go
Starting application...
Version:      v0.1.4-4-g0f38c47
Git revision: 0f38c47
Git branch:   feat/include-version-info-in-logs
Go version:   go1.21.6
Built:        Sun, 28 Apr 2024 07:44:44 +0000
OS/Arch:      linux/amd64
```

It also adds version printed out alongside process id on each log entry.

For example:
```go
2024-04-28T07:45:59.582Z	[INFO]	cmd/main.go:91	running migrations up	{"pid": 1, "version": "v0.1.4-4-g0f38c47"}
```
